### PR TITLE
Fix thumbnail downloading and local serving

### DIFF
--- a/frontend/src/components/ArchiveCard.tsx
+++ b/frontend/src/components/ArchiveCard.tsx
@@ -44,7 +44,7 @@ const ArchiveCard: React.FC<Props> = ({ entry, onDelete, onHardDelete }) => {
           <CardMedia
             component="img"
             height={180}
-            image={entry.thumbnail}
+            image={`${serverAddr}${entry.thumbnail}?token=${localStorage.getItem('token')}`}
           /> :
           <Skeleton variant="rectangular" height={180} />
         }

--- a/frontend/src/components/DownloadCard.tsx
+++ b/frontend/src/components/DownloadCard.tsx
@@ -65,7 +65,7 @@ const DownloadCard: React.FC<Props> = ({ download, onStop, onCopy }) => {
           <CardMedia
             component="img"
             height={180}
-            image={download.info.thumbnail}
+            image={`${serverAddr}${download.info.thumbnail}?token=${localStorage.getItem('token')}`}
           /> :
           <Skeleton variant="rectangular" height={180} />
         }

--- a/frontend/src/components/FormatsGrid.tsx
+++ b/frontend/src/components/FormatsGrid.tsx
@@ -1,4 +1,6 @@
 import { Button, ButtonGroup, Grid, Paper, Typography } from "@mui/material"
+import { useAtomValue } from 'jotai'
+import { serverURL } from '../atoms/settings'
 import type { DLMetadata } from '../types'
 
 type Props = {
@@ -24,6 +26,7 @@ export default function FormatsGrid({
   pickedAudioFormat,
   pickedVideoFormat,
 }: Props) {
+  const serverAddr = useAtomValue(serverURL)
   return (
     <Grid container spacing={2} mt={2}>
       <Grid item xs={12}>
@@ -42,7 +45,7 @@ export default function FormatsGrid({
               {/* <Skeleton variant="rectangular" height={180} /> */}
             </Grid>
             <Grid item xs={12} pb={1}>
-              <img src={downloadFormats.thumbnail} height={260} width="100%" style={{ objectFit: 'cover' }} />
+              <img src={`${serverAddr}${downloadFormats.thumbnail}?token=${localStorage.getItem('token')}`} height={260} width="100%" style={{ objectFit: 'cover' }} />
             </Grid>
             {/* video only */}
             <Grid item xs={12}>

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -204,7 +204,8 @@
             "type": "string"
           },
           "thumbnail": {
-            "type": "string"
+            "type": "string",
+            "description": "Proxy endpoint serving the thumbnail image"
           },
           "resolution": {
             "type": "string"

--- a/server/archive/service/service.go
+++ b/server/archive/service/service.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 
+	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/filebrowser"
+
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/archive/data"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/archive/domain"
 )
@@ -41,7 +43,7 @@ func (s *Service) HardDelete(ctx context.Context, id string) (*domain.ArchiveEnt
 		Id:        res.Id,
 		Title:     res.Title,
 		Path:      res.Path,
-		Thumbnail: res.Thumbnail,
+		Thumbnail: filebrowser.ThumbnailURL(res.Thumbnail),
 		Source:    res.Source,
 		Metadata:  res.Metadata,
 		CreatedAt: res.CreatedAt,
@@ -59,7 +61,7 @@ func (s *Service) SoftDelete(ctx context.Context, id string) (*domain.ArchiveEnt
 		Id:        res.Id,
 		Title:     res.Title,
 		Path:      res.Path,
-		Thumbnail: res.Thumbnail,
+		Thumbnail: filebrowser.ThumbnailURL(res.Thumbnail),
 		Source:    res.Source,
 		Metadata:  res.Metadata,
 		CreatedAt: res.CreatedAt,
@@ -84,7 +86,7 @@ func (s *Service) List(
 			Id:        model.Id,
 			Title:     model.Title,
 			Path:      model.Path,
-			Thumbnail: model.Thumbnail,
+			Thumbnail: filebrowser.ThumbnailURL(model.Thumbnail),
 			Source:    model.Source,
 			Metadata:  model.Metadata,
 			CreatedAt: model.CreatedAt,

--- a/server/rest/service.go
+++ b/server/rest/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/config"
+	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/filebrowser"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/internal"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/internal/livestream"
 )
@@ -51,7 +52,11 @@ func (s *Service) Running(ctx context.Context) (*[]internal.ProcessResponse, err
 	case <-ctx.Done():
 		return nil, context.Canceled
 	default:
-		return s.mdb.All(), nil
+		res := s.mdb.All()
+		for i := range *res {
+			(*res)[i].Info.Thumbnail = filebrowser.ThumbnailURL((*res)[i].Info.Thumbnail)
+		}
+		return res, nil
 	}
 }
 

--- a/server/rpc/service.go
+++ b/server/rpc/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/filebrowser"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/formats"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/internal"
 	"github.com/marcopiovanello/yt-dlp-web-ui/v3/server/internal/livestream"
@@ -121,7 +122,11 @@ func (s *Service) Pending(args NoArgs, pending *Pending) error {
 
 // Running retrieves a slice of all Processes progress
 func (s *Service) Running(args NoArgs, running *Running) error {
-	*running = *s.db.All()
+	res := s.db.All()
+	for i := range *res {
+		(*res)[i].Info.Thumbnail = filebrowser.ThumbnailURL((*res)[i].Info.Thumbnail)
+	}
+	*running = *res
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -153,6 +153,7 @@ func RunBlocking(rc *RunConfig) {
 
 func newServer(c serverConfig) *http.Server {
 	archiver.Register(c.db)
+	internal.OnComplete = archiver.PublishProcess
 
 	cronTaskRunner := task.NewCronTaskRunner(c.mq, c.mdb)
 	go cronTaskRunner.Spawner(context.TODO())
@@ -198,6 +199,7 @@ func newServer(c serverConfig) *http.Server {
 		r.Post("/delete", filebrowser.DeleteFile)
 		r.Get("/d/{id}", filebrowser.DownloadFile)
 		r.Get("/v/{id}", filebrowser.SendFile)
+		r.Get("/t/{id}", filebrowser.SendThumbnail)
 		r.Get("/bulk", filebrowser.BulkDownload(c.mdb))
 	})
 


### PR DESCRIPTION
## Summary
- store downloaded thumbnails locally and proxy via new endpoint
- allow the server to archive finished downloads through a callback
- revert stylistic churn in UI components while adding local thumbnail URLs
- consolidate thumbnail handler with other file operations

## Testing
- `make all` *(fails: pnpm could not download dependencies)*
- `go build ./...` *(fails: go toolchain download blocked)*